### PR TITLE
Fix bugs when admin hides and moves navigation menu items

### DIFF
--- a/src/components/AdminContextAreaManagement/InformationArchitecture/IAComponents/NavigationMenuItem/NavigationMenuItem.js
+++ b/src/components/AdminContextAreaManagement/InformationArchitecture/IAComponents/NavigationMenuItem/NavigationMenuItem.js
@@ -7,7 +7,7 @@ import {GoTriangleRight} from "react-icons/go";
 
 export default function NavigationMenuItem(
     {itemType, isActive, onPressChangeVisibility, item, onPressLoadItems,
-        isOverDrag, isStartDrag, changeDraggable, categories, moveItem}) {
+        isOverDrag, isStartDrag, changeDraggable, categories, AllSubcategories, moveItem}) {
 
     const [isItemHovering, setIsItemHovering] = useState(false);
     const [isMoveToHovering, setMoveToHovering] = useState(false);
@@ -79,7 +79,7 @@ export default function NavigationMenuItem(
                 setSubcategories([]);
             } else {
                 setActiveClickCategory(id);
-                setSubcategories(subcategories.filter(item => item.categoryId === id));
+                setSubcategories(AllSubcategories.filter(item => item.categoryId === id));
             }
         }
     }
@@ -180,7 +180,7 @@ export default function NavigationMenuItem(
                                             )}
                                             {(activeClickCategory === c.id && itemType === "team") && (
                                                 <div className="dropDown-subcategories">
-                                                    {subcategories.filter(item => item.id !== item.subcategoryId)
+                                                    {subcategories.filter(element => element.id !== item.subcategoryId)
                                                         .map((s, index) =>
                                                             <div className="dropDown-menu-element" key={index}
                                                                  onClick={(e) => handleSubcategoryClick(e, s.id)}>

--- a/src/components/AdminContextAreaManagement/InformationArchitecture/InformationArchitecturePage.js
+++ b/src/components/AdminContextAreaManagement/InformationArchitecture/InformationArchitecturePage.js
@@ -159,6 +159,8 @@ export default function InformationArchitecturePage() {
             movedItem = {...currentItem.item, subcategoryId: item.id, orderIndex: newOrderIndex};
         } else if (itemType === "category") {
             movedItem = {...currentItem.item, categoryId: item.id, orderIndex: newOrderIndex};
+            setTeams([])
+            setActiveSubcategory({id: -1, index: -1})
         }
 
         itemsStates[currentItem.type].setItems(itemsStates[currentItem.type].items
@@ -347,7 +349,7 @@ export default function InformationArchitecturePage() {
                                     <NavigationMenuItem key={index} item = {x} itemType="team" isOverDrag = {dragOverItemId === x.id}
                                                         onPressChangeVisibility={() => changeItemVisibility("team", x)}
                                                         isStartDrag={currentItem !== {} ? currentItem.item.id === x.id : false}
-                                                        categories={categories} subcategories = {subcategories}
+                                                        categories={categories} AllSubcategories = {subcategories}
                                                         moveItem = {moveItem} changeDraggable = {setIsDragAvailable}/>
                                 </div>
                             )}


### PR DESCRIPTION
### Summary of changes:

- Add "move to" button to change an item's parent;
- Add dnd to change the order of navigation menu items;
- Add "show" and "hide" buttons to change an item's visibility;

[User Story Requirements SPHUB-55](https://github.com/dark-side/lanthanum/tree/master/sports_hub_portal/web_application_features/maintain_navigation/user_stories/hide_show_navigation_items)
[User Story Requirements SPHUB-56](https://github.com/dark-side/lanthanum/tree/master/sports_hub_portal/web_application_features/maintain_navigation/user_stories/move_and_order_navigation_items)